### PR TITLE
Keep Haml at 4.x until 5.x issues are resolved.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "middleman-minify-html", "~> 3.4"
 gem 'redcarpet', '~> 3.3', '>= 3.3.3'
 gem "bourbon", "~> 5.0.0.beta.7"
 gem "neat", "~> 2.0.0"
+gem "haml", "~> 4.0"
 
 # For feed.xml.builder
 gem "builder", "~> 3.0"


### PR DESCRIPTION
* Reference middleman/middleman#2087