### PR TITLE
Don't cache feed.xml

### DIFF
--- a/environments/production.rb
+++ b/environments/production.rb
@@ -9,3 +9,4 @@ activate :asset_host, host: "https://d1ll4tgr741o0l.cloudfront.net"
 # https://github.com/fredjean/middleman-s3_sync#http-caching
 default_caching_policy max_age: (60 * 60 * 24 * 365)
 caching_policy "text/html", public: true, max_age: 0, must_revalidate: true
+caching_policy "application/xml", no_cache: true


### PR DESCRIPTION
I figured out why MailChimp wasn't seeing an updated feed on our blogs. The culprit wasn't CloudFront, but incorrect HTTP cache headers! The change in this PR turns off caching completely for xml files. To see the difference, run the following curl commands and compare the `Cache-Control:` lines:

    $ curl -IL https://ofreport.com/feed.xml
    $ curl -IL https://daysinukraine.com/feed.xml

Also, after you deploy this change, run an invalidation on CloudFront to make sure it's available right away.