### PR TITLE
Contact Form Update

### DIFF
--- a/source/subscribe.html.erb
+++ b/source/subscribe.html.erb
@@ -4,13 +4,12 @@ title: Subscribe
 
 <h1>Subscribe</h1>
 <p>
-  To be notified when a new post is available, enter your email address below.
+  To be notified when a new post is available, click the link below.
 </p>
-<form action="http://euroteamoutreach.us6.list-manage1.com/subscribe/post?u=f894325bd45c8fa3a88fc4d00&amp;id=14b6920411" method="post" name="mc-embedded-subscribe-form" target="_blank" class="mb-4">
-	<input name="EMAIL" placeholder="Email Address" type="email" class="w-3/4 p-2 border border-gray-300 rounded shadow-inner hover:border-gray-500 transition duration-100 hover:cursor-text ease-out focus:outline-none focus:shadow-outline"></input>
-	<input class="block px-4 py-2 mt-4 text-gray-100 bg-blue-700 rounded hover:bg-blue-600 hover:pointer transition duration-200 ease-out" name="subscribe" type="submit" value="Subscribe"></input>
-</form>
+<p>
+  <%= link_to "Subscribe to our blog.", "https://daysinukraine.us6.list-manage.com/subscribe?u=f894325bd45c8fa3a88fc4d00&id=14b6920411", target: "_blank", rel: "noopener" %>
+</p>
 <p>Don't want to get emails from us anymore?</p>
 <p>
-	<%= link_to "Unsubscribe from our blog.", "http://euroteamoutreach.us6.list-manage.com/unsubscribe?u=f894325bd45c8fa3a88fc4d00&id=14b6920411", target: "_blank", rel: "noopener" %>
+  <%= link_to "Unsubscribe from our blog.", "http://euroteamoutreach.us6.list-manage.com/unsubscribe?u=f894325bd45c8fa3a88fc4d00&id=14b6920411", target: "_blank", rel: "noopener" %>
 </p>

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -13,8 +13,7 @@ describe "subscribe page", type: :feature do
     expect(page).to have_css("h1", text: "Subscribe")
   end
 
-  it "display a signup box" do
-    # expect(page).to have_css(:form)
-    expect(page).to have_css("input.shadow-inner")
+  it "display the signup link" do
+    expect(page).to have_css("a", text: "Subscribe to our blog.")
   end
 end


### PR DESCRIPTION
Some folks were having trouble subscribing to our blog, and the form, while it was still working for some, was throwing warnings about being insecure. So I swapped out my form for a link to the form that Mailchimp hosts.